### PR TITLE
Fix option injection in !packages command

### DIFF
--- a/botsrc/nixbot/handler_package.go
+++ b/botsrc/nixbot/handler_package.go
@@ -44,6 +44,7 @@ func (nb *NixBot) CommandHandlerSearchPackages(ctx context.Context, client *maut
 		"nix", "search",
 		"-I", "nixpkgs=channel:nixos-unstable",
 		"--json",
+		"--",
 		"nixpkgs",
 		search,
 	)


### PR DESCRIPTION
### Issue

When `nix search` is called, the search term is added to argv in a position where options are accepted, so the user can pass one arbitrary option to nix. The `-f` option is particularly problematic.

### Exploits

DoS:

```
> !packages -f/dev/zero
Error: exit status 1
error: out of memory
```

Data exfiltration:

```
> !packages -f/etc/passwd
Error: exit status 1
error: syntax error, unexpected ':', expecting end of file

       at /etc/passwd:12:39:

           11| dhcpcd:x:999:999::/var/empty:/run/current-system/sw/bin/nologin
           12| nixbld1:x:30001:30000:Nix build user 1:/var/empty:/run/current-system/sw/bin/nologin
             |                                       ^
           13| nixbld2:x:30002:30000:Nix build user 2:/var/empty:/run/current-system/sw/bin/nologin
```

### Fix

Use `--` to signal the end of options